### PR TITLE
refactor: add whitespace before args for readability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,15 +72,15 @@ runs:
           $project = [System.IO.FileInfo]$p
 
           uipcli package analyze "$($project.FullName)" `
-          --stopOnRuleViolation `
-          --analyzerTraceLevel "Info" `
-          --orchestratorUrl "${{ inputs.orchestratorUrl }}" `
-          --orchestratorTenant "${{ inputs.OrchestratorTenant }}" `
-          --orchestratorAccountForApp "${{ inputs.orchestratorLogicalName }}" `
-          --orchestratorApplicationId "${{ inputs.orchestratorApplicationId }}" `
-          --orchestratorApplicationSecret "${{ inputs.orchestratorApplicationSecret }}" `
-          --orchestratorApplicationScope "${{ inputs.orchestratorApplicationScope }}" `
-          --orchestratorFolder "${{ inputs.orchestratorFolder }}"
+            --stopOnRuleViolation `
+            --analyzerTraceLevel "Info" `
+            --orchestratorUrl "${{ inputs.orchestratorUrl }}" `
+            --orchestratorTenant "${{ inputs.OrchestratorTenant }}" `
+            --orchestratorAccountForApp "${{ inputs.orchestratorLogicalName }}" `
+            --orchestratorApplicationId "${{ inputs.orchestratorApplicationId }}" `
+            --orchestratorApplicationSecret "${{ inputs.orchestratorApplicationSecret }}" `
+            --orchestratorApplicationScope "${{ inputs.orchestratorApplicationScope }}" `
+            --orchestratorFolder "${{ inputs.orchestratorFolder }}"
 
           if($LASTEXITCODE -ne 0)
           {

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
           Write-Host "Analyzing project: $p"
           $project = [System.IO.FileInfo]$p
 
-          & uipcli package analyze "$($project.FullName)" `
+          uipcli package analyze "$($project.FullName)" `
           --stopOnRuleViolation `
           --analyzerTraceLevel "Info" `
           --orchestratorUrl "${{ inputs.orchestratorUrl }}" `


### PR DESCRIPTION
Add whitespaces before uipcli arguments on newlines to improve readability of the code. Remove "&" operator on uicli, as it is not needed for the command to run