### PR TITLE
feat: add output for analyzer results path

### DIFF
--- a/.commitsar.yaml
+++ b/.commitsar.yaml
@@ -1,0 +1,7 @@
+version: 1
+verbose: true
+commits:
+  strict: true
+  disabled: false
+pull_request:
+  conventional: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: Mikael-RnD/setup-uipath@v1
       
       - name: 'Analyze with RuleConfig.json input'
+        id: analyze
         uses: ./
         with:
           orchestratorUrl: "https://cloud.uipath.com/"
@@ -36,6 +37,13 @@ jobs:
           orchestratorApplicationScope: ${{ secrets.UIPATH_APP_SCOPE }} 
           orchestratorLogicalName: ${{ secrets.UIPATH_ORGANIZATION_ID }}
           rulesConfigFile: 'RulesConfig.json'
+
+      - run: echo ${{ steps.analyze.outputs.analyzerResultsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: workflow-analyzer-results
+          path: ${{ steps.analyze.outputs.analyzerResultsPath }}
 
   analyze-no-rules-config:
     # The type of runner that the job will run on

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,25 @@
+# This is a workflow to check the contents of a pull request to main
+
+name: PR Checks
+
+# Controls when the workflow will run
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  commitsar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Commitsar
+        uses: aevea/commitsar@v0.20.2
+        with: 
+          config: .commitsar.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Example usage:
           orchestratorApplicationSecret: # Application Secret for External Application in Orchestrator
           orchestratorApplicationScope: # Scope for the assigned external applicaiton
           orchestratorLogicalName: # Password for basic authentication
+
+## Outputs
+ |Name|Description|
+ |:--|:--|
+ |analyzerResultsPath|A path on the local runner containing the analyzer result json files for all analyzed projects|

--- a/action.yml
+++ b/action.yml
@@ -29,11 +29,16 @@ inputs:
     description: 'Path to a RulesConfig.json for customized workflow analysis rules'
     required: false
     default: ""
+outputs:
+  analyzerResultsPath:
+    description: 'Folder containing the workflow analysis result files in json format, intended for use cases such as uploading to artifact for review'
+    value: ${{ steps.analyze.outputs.analyzerResultsPath }}
 
 runs:
   using: "composite"
   steps:
-    - name: Analyze
+    - id: analyze
+      name: Analyze
       shell: powershell
       run: |
         $analysisFailed = 0
@@ -66,10 +71,21 @@ runs:
           $projectJsonFiles = $projectJsonFiles -split "`r`n"
           $projectJsonFiles | Where { -not  [string]::IsNullOrWhiteSpace($_) } | Get-ChildItem -File
         }
+
+        $analyzerResultPath = "${{ github.workspace }}\analyzer-results".Trim()
+
+        Write-Output "analyzerResultsPath=$analyzerResultPath" >> $Env:GITHUB_OUTPUT
+        
+        New-Item -ItemType "directory" -Path $analyzerResultPath
+
         foreach($p in $projectJsonFiles)
         {
           Write-Host "Analyzing project: $p"
           $project = [System.IO.FileInfo]$p
+          $projectInfo = Get-Content "$($project.FullName)" | ConvertFrom-Json
+          $projectName = $projectInfo.name 
+          $analyzerResultFile = "$analyzerResultPath\" + $projectName + ".json"
+          Write-Host "Creating result file $analyzerResultFile"
 
           uipcli package analyze "$($project.FullName)" `
             --stopOnRuleViolation `
@@ -80,7 +96,10 @@ runs:
             --orchestratorApplicationId "${{ inputs.orchestratorApplicationId }}" `
             --orchestratorApplicationSecret "${{ inputs.orchestratorApplicationSecret }}" `
             --orchestratorApplicationScope "${{ inputs.orchestratorApplicationScope }}" `
-            --orchestratorFolder "${{ inputs.orchestratorFolder }}"
+            --orchestratorFolder "${{ inputs.orchestratorFolder }}" `
+            --resultPath "$analyzerResultFile"
+
+          Write-Host "Analyzer finished with $projectName"
 
           if($LASTEXITCODE -ne 0)
           {
@@ -91,3 +110,17 @@ runs:
         {
           throw "Workflow analysis failed"
         }
+        
+        $analyzerResultFiles = Get-ChildItem $analyzerResultPath
+        foreach($file in $analyzerResultFiles){
+          Write-Host $file.FullName
+        }
+
+        echo "Workflow analysis results created in path $analyzerResultPath" >> $Env:GITHUB_STEP_SUMMARY
+
+    - id: print_outputs
+      name: Print Outputs
+      if: always()
+      shell: pwsh
+      run:  |
+        echo "analyzerResultsPath: ${{ steps.analyze.outputs.analyzerResultsPath }}"


### PR DESCRIPTION
Add output to action for the analyzer results path on the GitHub Actions Runner.

Intended to be used by other actions, such as upload artifact to enable upload of analysis results
