### PR TITLE
fix: ignoredRules using correct formatting for uipcli

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
         }
         else {
           Write-Host "Ignoring rules: ${{ inputs.ignoredRules }}"
-          $ignoredRulesArg = "--ignoredRules=""${{ inputs.ignoredRules }}"""
+          $ignoredRulesArg = "--ignoredRules '${{ inputs.ignoredRules }}'"
           Write-Host $ignoredRulesArg
         }
 


### PR DESCRIPTION
Always pass the ignoredRules argument to the uipcli, even if the input is empty. This is done to clean up the code and make sure that the ignoredRules input on uipcli invocation is passed correctly