### PR TITLE
fix: set analyzerResultsTable output correctly

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -197,7 +197,7 @@ runs:
         }
 
         echo 'analyzerResultsTable<<EOF' >> $Env:GITHUB_OUTPUT
-        echo "$analyzerStepSummary" >> $Env:GITHUB_STEP_OUTPUT
+        echo $analyzerStepSummary.Trim() >> $Env:GITHUB_OUTPUT
         echo EOF >> $Env:GITHUB_OUTPUT
 
         echo "## Workflow Analysis Results" >> $Env:GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The line setting the GITHUB_OUTPUT was referring to an incorrect environment variable