### PR TITLE
feat: add info, warning and error count as outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
       - uses: Mikael-RnD/setup-uipath@v1
-      - name: Analyse with ignored rules
+      - id: analyze
+        name: Analyse with ignored rules
         uses: ./
         with:
           orchestratorUrl: "https://cloud.uipath.com/"
@@ -64,6 +65,13 @@ jobs:
           orchestratorApplicationScope: ${{ secrets.UIPATH_APP_SCOPE }} 
           orchestratorLogicalName: ${{ secrets.UIPATH_ORGANIZATION_ID }}
           ignoredRules: "ST-SEC-009,ST-USG-010,ST-MRD-034"
+      
+      - name: Print Outputs
+        run: |
+          echo "Analyzer results: ${{ steps.analyze.outputs.analyzerResultsTable }}"
+          echo "Info count: ${{ steps.analyze.outputs.infoCount }}"
+          echo "Warning count: ${{ steps.analyze.outputs.warningCount }}"
+          echo "Error count: ${{ steps.analyze.outputs.errorCount }}"
 
   analyze-with-path-input:
       # The type of runner that the job will run on

--- a/README.md
+++ b/README.md
@@ -73,3 +73,6 @@ The example below shows a use-case for running workflow analysis, on a specific 
 |:--|:--|
 |**analyzerResultsPath**|A path on the local runner containing the analyzer result json files for all analyzed projects|
 |**analyzerResultsTable**|Markdown formatted table containing the workflow analysis results, intended for use cases such as providing additional details in issues or pull request comments|
+|**infoCount**|Number of informational entries generated during analysis|
+|**warningCount**|Number of warning entries generated during analysis|
+|**errorCount**|Number of error entries generated during analysis|

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,15 @@ outputs:
   analyzerResultsTable: 
     description: 'Markdown formatted table containing the workflow analysis results, intended for use cases such as writing to the step summary and sending as a comment to a pull request'
     value: ${{ steps.parse.outputs.analyzerResultsTable }}
+  infoCount:
+    description: 'Number of informational entries generated during analysis'
+    value: ${{ steps.parse.outputs.infoCount }}
+  warningCount:
+    description: 'Number of warning entries generated during analysis'
+    value: ${{ steps.parse.outputs.warningCount }}
+  errorCount:
+    description: 'Number of error entries generated during analysis'
+    value: ${{ steps.parse.outputs.errorCount }}
 
 runs:
   using: "composite"
@@ -141,6 +150,9 @@ runs:
 
         $analyzerResultFiles = Get-ChildItem $analyzerResultPath
         $analyzerStepSummary = ""
+        $totalErrorCount = 0
+        $totalWarningCount = 0
+        $totalInfoCount = 0
 
         foreach($file in $analyzerResultFiles){
           Write-Host $file.FullName
@@ -196,6 +208,10 @@ runs:
           $analyzerStepSummary += $projectSummary  
           $analyzerStepSummary += "`n$analyzerTable"
           $analyzerStepSummary += "`n</details>`n"
+
+          $totalErrorCount += $errorCount
+          $totalWarningCount += $warningCount
+          $totalInfoCount += $infoCount
         }
 
         echo 'analyzerResultsTable<<EOF' >> $Env:GITHUB_OUTPUT
@@ -205,3 +221,7 @@ runs:
         echo "## Workflow Analysis Results" >> $Env:GITHUB_STEP_SUMMARY
         echo "" >> $Env:GITHUB_STEP_SUMMARY
         echo "$analyzerStepSummary" >> $Env:GITHUB_STEP_SUMMARY
+
+        echo "errorCount=$totalErrorCount" >> $Env:GITHUB_OUTPUT
+        echo "warningCount=$totalWarningCount" >> $Env:GITHUB_OUTPUT
+        echo "infoCount=$totalInfoCount" >> $Env:GITHUB_OUTPUT


### PR DESCRIPTION
Add outputs infoCount, warningCount and errorCount from the action to keep track of the number of entries per type generated during workflow analysis