### PR TITLE
feat: order results by filepath after severity

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -167,8 +167,8 @@ runs:
 
           $analyzerResult = Get-Content "$($file.FullName)" | ConvertFrom-Json
           $analyzerResult = $analyzerResult | Sort-Object -Property ErrorSeverity, FilePath
-          $analyzerTable = "|Severity|ErrorCode|RuleName|Description|Recommendation|DocumentationLink|FilePath|"
-          $analyzerTable += "`n|:--|:--|:--|:--|:--|:--|:--|`n"
+          $analyzerTable = "|Severity|ErrorCode/DocumentationLink|RuleName|Description|Recommendation|FilePath|"
+          $analyzerTable += "`n|:--|:--|:--|:--|:--|:--|`n"
           
           for($i = 0; $i -lt $analyzerResult.Length; $i++){
             if($($analyzerResult[$i].ErrorSeverity) -eq "3"){
@@ -201,7 +201,7 @@ runs:
               $recommendation = "$($analyzerResult[$i].Recommendation.Replace([System.Environment]::NewLine, ''))"
             }
 
-            $analyzerTable += "| $severity | $($analyzerResult[$i].ErrorCode) | $($analyzerResult[$i].RuleName) | $description | $recommendation | $($analyzerResult[$i].DocumentationLink) | $($analyzerResult[$i].FilePath) |`n"
+            $analyzerTable += "| $severity | [$($analyzerResult[$i].ErrorCode)]($($analyzerResult[$i].DocumentationLink)) | $($analyzerResult[$i].RuleName) | $description | $recommendation | $($analyzerResult[$i].FilePath) |`n"
           }
           $projectSummary = "`n - ${errorSummary} `n - ${warningSummary} `n - ${infoSummary} `n"
           $analyzerStepSummary += $projectHeader

--- a/action.yml
+++ b/action.yml
@@ -166,7 +166,7 @@ runs:
           $errorText = ":x: Error"
 
           $analyzerResult = Get-Content "$($file.FullName)" | ConvertFrom-Json
-          $analyzerResult = $analyzerResult | Sort-Object -Property ErrorSeverity
+          $analyzerResult = $analyzerResult | Sort-Object -Property ErrorSeverity, FilePath
           $analyzerTable = "|Severity|ErrorCode|RuleName|Description|Recommendation|DocumentationLink|FilePath|"
           $analyzerTable += "`n|:--|:--|:--|:--|:--|:--|:--|`n"
           


### PR DESCRIPTION
Improve visualisation of analysis results by order results by file path after having sorted by severity, and combining the DocumentationLink/ErrorCode columns to reduce the output table