### PR TITLE
fix: read analyzer results with space in file names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -133,7 +133,10 @@ runs:
         echo "analyzerResultsPath: ${{ steps.analyze.outputs.analyzerResultsPath }}"
         analyzerResultPath="${{ steps.analyze.outputs.analyzerResultsPath }}"
 
-        analyzerResultFiles=$(find "$analyzerResultPath" -type f)
+        find "$analyzerResultPath" -type f | while IFS= read -r file; do
+          analyzerResultFiles+=("$file")
+        done
+        
         analyzerStepSummary=""
         totalErrorCount=0
         totalWarningCount=0


### PR DESCRIPTION
Fix bug where paths containing file names were not passed correctly into parsing analysis results