### PR TITLE
fix: ignore rules correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the workflow will run
+# Controls when the workflow will run 
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -14,6 +14,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  analyze-with-ignored-rules:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - uses: Mikael-RnD/setup-uipath@v2
+      
+      - name: 'Analyze with RuleConfig.json input'
+        id: analyze
+        uses: ./
+        with:
+          orchestratorUrl: "https://cloud.uipath.com/"
+          orchestratorTenant: ${{ secrets.UIPATH_TENANT }}
+          orchestratorFolder: Shared
+          orchestratorApplicationId: ${{ secrets.UIPATH_APP_ID }}
+          orchestratorApplicationSecret: ${{ secrets.UIPATH_APP_SECRET }}
+          orchestratorApplicationScope: ${{ secrets.UIPATH_APP_SCOPE }} 
+          orchestratorLogicalName: ${{ secrets.UIPATH_ORGANIZATION_ID }}
+          ignoredRules: ST-USG-010
+          
   # This workflow contains a single job called "build"
   analyze-with-rules-config:
     # The type of runner that the job will run on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the workflow will run 
+# Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -14,30 +14,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  analyze-with-ignored-rules:
-    # The type of runner that the job will run on
-    runs-on: windows-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-
-      - uses: Mikael-RnD/setup-uipath@v2
-      
-      - name: 'Analyze with RuleConfig.json input'
-        id: analyze
-        uses: ./
-        with:
-          orchestratorUrl: "https://cloud.uipath.com/"
-          orchestratorTenant: ${{ secrets.UIPATH_TENANT }}
-          orchestratorFolder: Shared
-          orchestratorApplicationId: ${{ secrets.UIPATH_APP_ID }}
-          orchestratorApplicationSecret: ${{ secrets.UIPATH_APP_SECRET }}
-          orchestratorApplicationScope: ${{ secrets.UIPATH_APP_SCOPE }} 
-          orchestratorLogicalName: ${{ secrets.UIPATH_ORGANIZATION_ID }}
-          ignoredRules: ST-USG-010
-          
   # This workflow contains a single job called "build"
   analyze-with-rules-config:
     # The type of runner that the job will run on

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,17 @@ outputs:
 
 runs:
   using: "composite"
+  shell: bash
   steps:
+    - id: parse-ignore-rules
+      run: |
+        if [ -z "${{ inputs.ignoredRules }}" ]; then
+          echo "No ignored rules provided"
+        else
+          echo "Ignoring rules: ${{ inputs.ignoredRules }}"
+          echo "ignoredRules=--ignoredRules "${{ inputs.ignoredRules }}"" >> $GITHUB_OUTPUT
+        fi
+  
     - id: analyze
       name: Analyze
       shell: bash
@@ -81,15 +91,6 @@ runs:
           projectJsonFiles=$(echo "${{ inputs.projectFilePaths }}" | tr '\r\n' '\n' | sed '/^\s*$/d' | while read -r line; do echo "${{ github.workspace }}/$line"; done)
         fi
 
-        if [ -z "${{ inputs.ignoredRules }}" ]; then
-          echo "No ignored rules provided"
-          ignoredRulesArg=""
-        else
-          echo "Ignoring rules: ${{ inputs.ignoredRules }}"
-          ignoredRulesArg="--ignoredRules=\"${{ inputs.ignoredRules }}\""
-          echo "$ignoredRulesArg"
-        fi
-
         analyzerResultPath="${{ github.workspace }}/analyzer-results"
         echo "analyzerResultsPath=$analyzerResultPath" >> "$GITHUB_OUTPUT"
         mkdir -p "$analyzerResultPath"
@@ -111,7 +112,7 @@ runs:
             --orchestratorApplicationScope "${{ inputs.orchestratorApplicationScope }}" \
             --orchestratorFolder "${{ inputs.orchestratorFolder }}" \
             --resultPath "$analyzerResultFile" \
-            $ignoredRulesArg
+            ${{ steps.parse-ignore-rules.outputs.ignoredRules }}
 
           echo "Analyzer finished with $projectName"
 

--- a/action.yml
+++ b/action.yml
@@ -54,9 +54,9 @@ outputs:
 
 runs:
   using: "composite"
-  shell: bash
   steps:
     - id: parse-ignore-rules
+      shell: bash
       run: |
         if [ -z "${{ inputs.ignoredRules }}" ]; then
           echo "No ignored rules provided"


### PR DESCRIPTION
Conversion of code from bash to Powershell for parsing ignoredRules had not been done correctly from v2.

Move parsing of ignoredRules to separate step, where this steps output is then used in the analyze command.