### PR TITLE
fix: sanitize newlines in file path on results

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -184,7 +184,9 @@ runs:
 
             description=$(echo "$result" | jq -r '.Description // ""' | tr '\r\n' ' ')
             recommendation=$(echo "$result" | jq -r '.Recommendation // ""' | tr '\r\n' ' ')
-            analyzerTable+="\n| $severity | [$(echo "$result" | jq -r '.ErrorCode // ""')]($(echo "$result" | jq -r '.DocumentationLink // ""')) | $(echo "$result" | jq -r '.RuleName // ""') | $description | $recommendation | $(echo "$result" | jq -r '.FilePath // ""') |"
+            filePath=$(echo "$result" | jq -r '.FilePath // ""' | tr -d '\r\n')  # Remove newlines
+
+            analyzerTable+="\n| $severity | [$(echo "$result" | jq -r '.ErrorCode // ""')]($(echo "$result" | jq -r '.DocumentationLink // ""')) | $(echo "$result" | jq -r '.RuleName // ""') | $description | $recommendation | $filePath |"
           done < temp_results.json
           rm temp_results.json
 


### PR DESCRIPTION
Sanitize any newline characters in analysis results FilePath properties