### PR TITLE
fix: make FilePath in analysis results relative

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -184,8 +184,7 @@ runs:
 
             description=$(echo "$result" | jq -r '.Description // ""' | tr '\r\n' ' ')
             recommendation=$(echo "$result" | jq -r '.Recommendation // ""' | tr '\r\n' ' ')
-            filePath=$(echo "$result" | jq -r '.FilePath // ""' | tr -d '\r\n' | sed "s|$GITHUB_WORKSPACE/||" | sed 's/[[:space:]]\+/ /g')
-
+            filePath=$(echo "$result" | jq -r '.FilePath // ""' | tr -d '\r\n' | sed 's|\\|/|g' | sed "s|$(echo $GITHUB_WORKSPACE | sed 's|\\|/|g')/||" | sed 's/[[:space:]]\+/ /g')
 
             analyzerTable+="\n| $severity | [$(echo "$result" | jq -r '.ErrorCode // ""')]($(echo "$result" | jq -r '.DocumentationLink // ""')) | $(echo "$result" | jq -r '.RuleName // ""') | $description | $recommendation | $filePath |"
           done < temp_results.json

--- a/action.yml
+++ b/action.yml
@@ -184,7 +184,7 @@ runs:
 
             description=$(echo "$result" | jq -r '.Description // ""' | tr '\r\n' ' ')
             recommendation=$(echo "$result" | jq -r '.Recommendation // ""' | tr '\r\n' ' ')
-            filePath=$(echo "$result" | jq -r '.FilePath // ""' | tr -d '\r\n' | sed 's/[[:space:]]\+/ /g')
+            filePath=$(echo "$result" | jq -r '.FilePath // ""' | tr -d '\r\n' | sed "s|$GITHUB_WORKSPACE/||" | sed 's/[[:space:]]\+/ /g')
 
 
             analyzerTable+="\n| $severity | [$(echo "$result" | jq -r '.ErrorCode // ""')]($(echo "$result" | jq -r '.DocumentationLink // ""')) | $(echo "$result" | jq -r '.RuleName // ""') | $description | $recommendation | $filePath |"


### PR DESCRIPTION
Reduce clutter in analysis results output table by changing all FilePath items in result table into their relative paths and remove unprinted characters