### PR TITLE
fix: print analyzer results

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -154,6 +154,8 @@ runs:
         for file in "${analyzerResultFiles[@]}"; do
           echo "::group::Analysis results for $(basename "$file" .json)"
 
+          cat "$file"
+
           errorCount=0
           warningCount=0
           infoCount=0


### PR DESCRIPTION
Print analyzer result file contents in its own dedicated section in GitHub Actions logs